### PR TITLE
Fixed memory leaks in matplotlib - CADC-10794

### DIFF
--- a/cfht2caom2/preview_augmentation.py
+++ b/cfht2caom2/preview_augmentation.py
@@ -227,6 +227,7 @@ class CFHTPreview(mc.PreviewVisitor):
             ProductType.PREVIEW,
             ReleaseType.DATA,
         )
+        fig.close()
         self.add_to_delete(self._preview_fqn)
         count = 1
         count += self._gen_thumbnail()
@@ -594,6 +595,7 @@ class CFHTPreview(mc.PreviewVisitor):
         plt.xlabel('Radial Velocity (km/s)')
         plt.ylabel('Weighted mean echelle order')
         plt.savefig(self._preview_fqn, format='jpg')
+        plt.close()
         return self._save_figure()
 
     def _do_spirou_intensity_spectrum(self):
@@ -671,6 +673,7 @@ class CFHTPreview(mc.PreviewVisitor):
         )
         plt.tight_layout()
         plt.savefig(self._preview_fqn, format='jpg')
+        plt.close()
         return self._save_figure()
 
     def _exec_cmd_chdir(self, temp_file, cmd):
@@ -779,6 +782,7 @@ class CFHTPreview(mc.PreviewVisitor):
             )
             if thumb is not None:
                 count = 1
+            thumb.clf()
         else:
             self._logger.warning(
                 f'Could not find {self._preview_fqn} for thumbnail '


### PR DESCRIPTION
The memory leak was in `matplotlib` and it's been documented in various places including https://github.com/matplotlib/matplotlib/issues/8519

Procedure
I've used the `guppy3` package to track down the problem. After installation, I've used a small script to invoke it and print the heap at the end of the run on 15 input datasets (had to comment out the `sys.exit` line on `composable.py:167`).
Script

```
from cfht2caom2.composable import run_by_builder

from guppy import hpy


if __name__ == "__main__":
    hs = hpy()
    hs.setref()
    run_by_builder()
    heap_snapshot = hs.heap()
    print(heap_snapshot)
```

The report at the end:
```
Partition of a set of 125772 objects. Total size = 18719863 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0   1462   1  3321664  18   3321664  18 dict of matplotlib.lines.Line2D
     1   1153   1  2619616  14   5941280  32 dict of matplotlib.text.Text
     2   8014   6  1828613  10   7769893  42 numpy.ndarray
     3  13085  10  1668664   9   9438557  50 dict (no owner)
     4   3804   3   841888   4  10280445  55 set
     5   2250   2   806328   4  11086773  59 dict of matplotlib.path.Path
     6   5626   4   765136   4  11851909  63 function
     7   9709   8   611160   3  12463069  67 list
     8   9275   7   552840   3  13015909  70 tuple
     9   4537   4   432316   2  13448225  72 str
```

Same run after the fix:
```
********************************
Location: work
Date: 2022-03-15T18:39:42.626837
Execution Time: 100.20 s
    Number of Inputs: 15
 Number of Successes: 15
  Number of Timeouts: 0
   Number of Retries: 0
    Number of Errors: 0
Number of Rejections: 0
********************************


Partition of a set of 11472 objects. Total size = 1339991 bytes.
 Index  Count   %     Size   % Cumulative  % Kind (class / dict of class)
     0   3992  35   402056  30    402056  30 str
     1   1605  14   134136  10    536192  40 tuple
     2    946   8    95168   7    631360  47 list
     3    310   3    87184   7    718544  54 set
     4    152   1    70424   5    788968  59 dict (no owner)
     5     50   0    58800   4    847768  63 dict of pyparsing.core.Forward
     6     27   0    55320   4    903088  67 re.Pattern
     7    452   4    48894   4    951982  71 bytes
     8    342   3    46512   3    998494  75 function
     9    214   2    38160   3   1036654  77 types.CodeType
<112 more rows. Type e.g. '_.more' to view.>
```

A potential improvement for the pipelines to protect against these kind of problems in the future would be to spawn a new separate process for each of these processing steps. These leaks will be automatically claimed with the process memory cleanup.
