### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN cd /usr/local/src && \
     rm -rf /usr/local/src/h5check-${H5CHECK_VERSION}
 
 ARG OPENCADC_BRANCH=main
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 RUN git clone https://github.com/opencadc/caom2tools.git && \
     cd caom2tools && \
     pip install ./caom2utils && \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ chmod +x cfht_run.sh
 ./cfht_run.sh
 ```
 
-4. The `config.yml` file is configuration information for the ingestion. This file will be created in the executing directory the first time the script `cfht_run.sh` is run. It will work with the files names and described here. For a complete description of its content, see https://github.com/opencadc/collection2caom2/wiki/config.yml.
+4. The `config.yml` file is configuration information for the ingestion. This file will be created in the executing directory the first time the script `cfht_run.sh` is run. It will work with the files names and described here. For a complete description of its content, see https://github.com/opencadc-metadata-curation/collection2caom2/wiki/config.yml.
 
 5. The ways to tell this tool the work to be done:
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ In an empty directory (the 'working directory'), on a machine with Docker instal
 1. In the master branch of this repository, find the scripts directory, and copy the file cfht_run.sh to the working directory. e.g.:
 
   ```
-  wget https://raw.github.com/opencadc/cfht2caom2/master/scripts/cfht_run.sh
+  wget https://raw.github.com/opencadc-metadata-curation/cfht2caom2/master/scripts/cfht_run.sh
   ```
 
 2. Ensure the script is executable:

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/cfht2caom2
+github_project = opencadc-metadata-curation/cfht2caom2
 # numpy version is because asscalar is missing from 1.23
 # that is required by astropy 4.3.1
 install_requires =


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n- Updated README documentation\n- Updated shell scripts\n
## Files Modified
```
Dockerfile
README.md
scripts/cfht_run.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
